### PR TITLE
Do not lint js and ts files

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
 		'stylelint-config-recommended-scss',
 		'stylelint-config-recommended-vue',
 	],
+	ignoreFiles: ['**/*.js', '**/*.ts'],
 	rules: {
 		indentation: 'tab',
 		'selector-type-no-unknown': null,


### PR DESCRIPTION
Otherwise we can have weird issues like those:
https://github.com/nextcloud/contacts/runs/4584577539?check_suite_focus=true

```bash
> Run npm run stylelint

> contacts@4.0.2 stylelint
> stylelint src


src/admin-settings.js
 32:2  ✖  Unknown word  CssSyntaxError

src/files-action.js
 22:10  ✖  Unknown word  CssSyntaxError

src/main.js
 23:10  ✖  Unknown word  CssSyntaxError

src/mixins/ActionsMixin.js
 27:17  ✖  Missed semicolon  CssSyntaxError

src/mixins/CircleActionsMixin.js
 22:10  ✖  Unknown word  CssSyntaxError

src/mixins/CopyToClipboardMixin.js
 23:10  ✖  Unknown word  CssSyntaxError
```