### PR TITLE
Do not lint svg files

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = {
 		'stylelint-config-recommended-scss',
 		'stylelint-config-recommended-vue',
 	],
-	ignoreFiles: ['**/*.js', '**/*.ts'],
+	ignoreFiles: ['**/*.js', '**/*.ts', '**/*.svg'],
 	rules: {
 		indentation: 'tab',
 		'selector-type-no-unknown': null,


### PR DESCRIPTION
Prevent failures like those

```bash
% npm run stylelint          

> viewer@1.8.0 stylelint
> stylelint src


src/assets/menu-sidebar-white.svg
 1:1  ✖  Unknown word  CssSyntaxError
```