### PR TITLE
Fix stylelint scss config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
 	extends: [
 		'stylelint-config-recommended-scss',
-		'stylelint-config-recommended-vue',
+        "stylelint-config-recommended-vue/scss"
 	],
 	ignoreFiles: ['**/*.js', '**/*.ts', '**/*.svg'],
 	rules: {
@@ -33,5 +33,4 @@ module.exports = {
 			},
 		],
 	},
-	plugins: ['stylelint-scss'],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
 			"devDependencies": {
 				"stylelint": "^14.0.1",
 				"stylelint-config-recommended-scss": "^5.0.1",
-				"stylelint-config-recommended-vue": "^1.0.0",
-				"stylelint-scss": "^4.0.0"
+				"stylelint-config-recommended-vue": "^1.0.0"
 			},
 			"engines": {
 				"node": "^14.0.0",
@@ -21,8 +20,7 @@
 			"peerDependencies": {
 				"stylelint": "^14.0.1",
 				"stylelint-config-recommended-scss": "^5.0.1",
-				"stylelint-config-recommended-vue": "^1.0.0",
-				"stylelint-scss": "^4.0.0"
+				"stylelint-config-recommended-vue": "^1.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -10,14 +10,12 @@
 	"peerDependencies": {
 		"stylelint": "^14.0.1",
 		"stylelint-config-recommended-scss": "^5.0.1",
-		"stylelint-config-recommended-vue": "^1.0.0",
-		"stylelint-scss": "^4.0.0"
+		"stylelint-config-recommended-vue": "^1.0.0"
 	},
 	"devDependencies": {
 		"stylelint": "^14.0.1",
 		"stylelint-config-recommended-scss": "^5.0.1",
-		"stylelint-config-recommended-vue": "^1.0.0",
-		"stylelint-scss": "^4.0.0"
+		"stylelint-config-recommended-vue": "^1.0.0"
 	},
 	"keywords": [
 		"stylelint",


### PR DESCRIPTION
- `stylelint-scss` is already included in https://github.com/stylelint-scss/stylelint-config-recommended-scss
- Comply to `stylelint-recommended-vue` guidelines for scss and fix linting
  https://github.com/ota-meshi/stylelint-config-recommended-vue#with-scss

Otherwise we get conflicts and it does this
```bash
% npm run stylelint                  

> photos@1.6.0 stylelint
> stylelint src


src/components/Navigation.vue
 147:1  ✖  Unexpected unknown at-rule "@use"         at-rule-no-unknown                
 148:1  ✖  Unexpected invalid position @import rule  no-invalid-position-at-import-rule
 177:2  ✖  Unexpected unknown at-rule "@include"     at-rule-no-unknown                
 181:3  ✖  Unexpected unknown at-rule "@if"          at-rule-no-unknown                

src/views/Albums.vue
 257:2  ✖  Unexpected unknown at-rule "@include"  at-rule-no-unknown

src/views/Tags.vue
 285:2  ✖  Unexpected unknown at-rule "@include"  at-rule-no-unknown

src/views/Timeline.vue
 302:2  ✖  Unexpected unknown at-rule "@include"  at-rule-no-unknown
```
