### PR TITLE
`::v-deep` is deprecated in favor of `:deep` as of vue 2.7

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ module.exports = {
 		'selector-pseudo-element-no-unknown': [
 			true,
 			{
-				// Vue v-deep pseudo-element
-				ignorePseudoElements: ['v-deep'],
+				// Vue deep pseudo-element
+				ignorePseudoElements: ['deep'],
 			},
 		],
 	},


### PR DESCRIPTION
`::v-deep` is deprecated starting from 2.7 and is removed with vue 3 in favor of `:deep`. So `:deep` should be favored.

(An alternative would be to allow both)