### PR TITLE
Also allow `:deep` as a pseudo class

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,13 @@ module.exports = {
 		'selector-list-comma-newline-after': null,
 		'no-descending-specificity': null,
 		'string-quotes': 'single',
+		'selector-pseudo-class-no-unknown': [
+                        true,
+                        {
+                                // vue deep pseudo-class
+                                ignorePseudoClasses: ['deep'],
+                        },
+                ],
 		'selector-pseudo-element-no-unknown': [
 			true,
 			{


### PR DESCRIPTION
`:deep` is also considered a pseudo class besides pseudo element, so this has to be allowed as well.